### PR TITLE
Add Telegram group notifications on PR updates

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -1,0 +1,21 @@
+name: GitHub Notifier
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, review_requested, reopened]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify telegram groups on pull request changes
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }} # don't change
+          token: ${{ secrets.TELEGRAM_TOKEN }} # don't change
+          message: |
+            **${{ github.event.pull_request.title }}**
+            @${{ github.actor }} created/updated a pull request.

--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify telegram groups on pull request changes
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@v0.1.1
         with:
           to: ${{ secrets.TELEGRAM_TO }} # don't change
           token: ${{ secrets.TELEGRAM_TOKEN }} # don't change


### PR DESCRIPTION
### Changes
- Add a new workflow `notifier.yml` to update the Telegram group on Pull Requests (i.e. opened, edited, ready for review, review requested and reopened)