### PR TITLE
Add dummy workflow to trigger notifier

### DIFF
--- a/.github/workflows/PRUpdates.yml
+++ b/.github/workflows/PRUpdates.yml
@@ -1,0 +1,15 @@
+name: PR Updates
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, review_requested, reopened]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  dummy-workflow:
+    runs-on: ubuntu-latest
+    name: dummy workflow
+    steps:
+      - name: Explanation
+        run: echo "this is a dummy workflow that triggers a workflow_run; it's necessary because otherwise the repo secrets will not be in scope for externally forked pull requests"

--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -1,10 +1,8 @@
 name: GitHub Notifier
 
 on:
-  pull_request:
-    types: [opened, edited, ready_for_review, review_requested, reopened]
-  pull_request_review_comment:
-    types: [created]
+  workflow_run:
+    workflows: ["PR Updates"]
 
 jobs:
   build:


### PR DESCRIPTION
### Changes
- Add dummy workflow `PRUpdates.yml` as repository secrets are not in scope for externally forked pull requests.