### PR TITLE
Add command alias for 'task'

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -48,7 +48,9 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command;
-        if (commandText.startsWith(TaskCommand.COMMAND_WORD) && Character.isWhitespace(commandText.charAt(4))) {
+        if ((commandText.startsWith(TaskCommand.COMMAND_WORD) && Character.isWhitespace(commandText.charAt(4)))
+            || (commandText.startsWith(TaskCommand.COMMAND_WORD_ALIAS)
+                && Character.isWhitespace(commandText.charAt(1)))) {
             command = taskPanelParser.parse(commandText);
         } else {
             command = addressBookParser.parseCommand(commandText);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -48,9 +48,10 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command;
-        if ((commandText.startsWith(TaskCommand.COMMAND_WORD) && Character.isWhitespace(commandText.charAt(4)))
-            || (commandText.startsWith(TaskCommand.COMMAND_WORD_ALIAS)
-                && Character.isWhitespace(commandText.charAt(1)))) {
+
+        // checks if command starts with "task" and creates separate parsers for task-related commands
+        if ((commandText.startsWith(TaskCommand.COMMAND_WORD + " "))
+            || (commandText.startsWith(TaskCommand.COMMAND_WORD_ALIAS + " "))) {
             command = taskPanelParser.parse(commandText);
         } else {
             command = addressBookParser.parseCommand(commandText);

--- a/src/main/java/seedu/address/logic/commands/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TaskCommand.java
@@ -5,4 +5,5 @@ package seedu.address.logic.commands;
  */
 public abstract class TaskCommand extends Command {
     public static final String COMMAND_WORD = "task";
+    public static final String COMMAND_WORD_ALIAS = "t";
 }

--- a/src/main/java/seedu/address/logic/parser/TaskPanelParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskPanelParser.java
@@ -24,10 +24,12 @@ import seedu.address.logic.parser.task.MarkTaskCommandParser;
  */
 public class TaskPanelParser implements Parser<TaskCommand> {
 
+    private static final String pattern = "(" + TaskCommand.COMMAND_WORD + "|" + TaskCommand.COMMAND_WORD_ALIAS + ")";
     /**
      * Used for initial separation of command word and args.
      */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("task\\s(?<commandWord>\\S+)(?<arguments>.*)");
+    private static final Pattern BASIC_COMMAND_FORMAT =
+        Pattern.compile(pattern + "\\s(?<commandWord>\\S+)(?<arguments>.*)");
 
     @Override
     public TaskCommand parse(String userInput) throws ParseException {


### PR DESCRIPTION
## Changes
- Add a command alias/short form for `task`: `t`. For more advanced users who want a faster experience, they can now type `t` instead of `task` (e.g., `task add NewTask`).

Fixes #87 