### PR TITLE
Update documentation for task list and deadline commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -146,13 +146,32 @@ Format: `task delete TASK_INDEX`
 Examples:
 * `task list` followed by `task delete 1` delete the 1st task from task list.
 
+### Setting deadlines to a task: `task do ... by/`
+
+You can use the `task do ... by/` command to set (or remove) a deadline for some task.
+
+Format: `task do TASK_INDEX [by/DATE]...`
+- The `task do` command sets the deadline specified by `DATE` to the task at the specified `TASK_INDEX` from the task list.
+- You can use plain English to describe the intended deadline, such as `today`, `tomorrow`, `next Thursday`, `14 November`, and so on.
+- If the application is unable to determine a date from your input, an error message will be displayed and you will be prompted to try a different input.
+- To **remove** the deadline from a task, you can use the special character `?`.
+
+Examples:
+* `task do 1 by/tomorrow` sets the deadline for the 1st task in the list to tomorrow.
+* `task do 1 by/?` **removes** the deadline from the 1st task in the list.
 
 ### Listing all tasks : `task list`
 
-Shows a list of all tasks stored in the application.
+You can use the `task list` command to focus only on tasks that match your specified filter requirements.
 
-Format: `task list`
+Format: `task list [ti/KEYWORD] [c/PERSON_INDEX]...`
+- The `task list` command accepts **optional** parameters that can filter tasks by their title or assigned contacts.
+- If you do not specify any filters (i.e. `task list`), the command returns **all** tasks. You may find this useful to reset the task list after performing some filtering.
 
+Examples:
+* `task list ti/fix` filters the task list to only display tasks that contain the keyword `fix`.
+* `task list c/1 c/2` filters the task list to only display tasks that are assigned to **both** the 1st and 2nd persons from the address book.
+* `task list ti/fix c/1 c/2` filters the task list to only display tasks that contain the keyword `fix` **and** that are assigned to **both** the 1st and 2nd persons from the address book.
 
 ### Assigning contacts to a task: `task assign`
 

--- a/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands.task;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -29,10 +30,11 @@ public class ListTasksCommand extends TaskCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD_FULL
             + ": Lists all tasks that satisfy the specified requirements.\n"
             + "Parameters: "
+            + "[" + PREFIX_TITLE + "KEYWORD]"
             + "[" + PREFIX_CONTACT + "CONTACT_INDEX]...\n"
             + "Example: " + COMMAND_WORD_FULL + " "
-            + PREFIX_CONTACT + "2 "
-            + PREFIX_CONTACT + "3 ";
+            + PREFIX_TITLE + "fix "
+            + PREFIX_CONTACT + "1 ";
 
     public static final String MESSAGE_SUCCESS = "Found %1$s tasks %2$s %3$s";
 

--- a/src/main/java/seedu/address/logic/parser/task/ListTasksCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/ListTasksCommandParser.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,9 +30,9 @@ public class ListTasksCommandParser implements Parser<ListTasksCommand> {
     public ListTasksCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CONTACT);
+                ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_CONTACT);
 
-        Optional<String> keywordFilter = argMultimap.getValue(PREFIX_NAME);
+        Optional<String> keywordFilter = argMultimap.getValue(PREFIX_TITLE);
         List<String> contactFilters = argMultimap.getAllValues(PREFIX_CONTACT);
 
         if (keywordFilter.isEmpty() && contactFilters.isEmpty() && !args.trim().isEmpty()) {

--- a/src/test/java/seedu/address/logic/parser/task/ListTasksCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/ListTasksCommandParserTest.java
@@ -21,12 +21,12 @@ public class ListTasksCommandParserTest {
     @Test
     public void parse_validArgs_returnsAssignTaskCommand() {
         assertParseSuccess(parser, "  ", new ListTasksCommand(Optional.empty(), new HashSet<>()));
-        assertParseSuccess(parser, " n/hi", new ListTasksCommand(Optional.of("hi"), new HashSet<>()));
+        assertParseSuccess(parser, " ti/hi", new ListTasksCommand(Optional.of("hi"), new HashSet<>()));
 
         assertParseSuccess(parser, " c/1", new ListTasksCommand(Optional.empty(),
                 new HashSet<>(Arrays.asList(INDEX_FIRST_PERSON))));
 
-        assertParseSuccess(parser, " n/hi c/1 c/2", new ListTasksCommand(Optional.of("hi"),
+        assertParseSuccess(parser, " ti/hi c/1 c/2", new ListTasksCommand(Optional.of("hi"),
                 new HashSet<>(Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON))));
     }
 


### PR DESCRIPTION
### Changes
- Modified the usage of the task list command in terms of the keyword prefix. It now uses the title prefix `ti/` instead of the previous name prefix `n/`