### PR TITLE
Add tag project to task feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -60,7 +60,8 @@ public class DeleteCommand extends Command {
         for (Task task : lastShownTaskList) {
             Set<Contact> newAssignedContactList = new HashSet<>(task.getAssignedContacts());
             newAssignedContactList.remove(contactToDelete);
-            Task newTask = new Task(task.getTitle(), task.getCompleted(), task.getDeadline(), newAssignedContactList);
+            Task newTask = new Task(task.getTitle(), task.getCompleted(), task.getDeadline(),
+                    task.getProject(), newAssignedContactList);
             model.setTask(task, newTask);
             modifiedTaskList.add(newTask);
         }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -103,7 +103,7 @@ public class EditCommand extends Command {
             Set<Contact> newAssignedContactList = new HashSet<>(task.getAssignedContacts());
             newAssignedContactList.remove(contactToEdit);
             newAssignedContactList.add(editedContact);
-            model.setTask(task, new Task(task.getTitle(), task.getCompleted(), task.getDeadline(),
+            model.setTask(task, new Task(task.getTitle(), task.getCompleted(), task.getDeadline(), task.getProject(),
                     newAssignedContactList));
         }
         model.updateFilteredTaskList(new AssignedToContactsPredicate(editedContact));

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
@@ -21,13 +22,15 @@ public class AddTaskCommand extends TaskCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD_FULL + ": Adds a task to the task panel. "
             + "Parameters: "
             + "TITLE "
-            + PREFIX_DEADLINE + "DEADLINE"
+            + PREFIX_DEADLINE + "DEADLINE "
+            + "[" + PREFIX_PROJECT + "PROJECT NAME] "
             + "[" + PREFIX_CONTACT + "CONTACT]...\n"
-            + "Example: " + COMMAND_WORD + " "
-            + "New task"
-            + PREFIX_DEADLINE + "14 December 2000"
-            + PREFIX_CONTACT + "1"
-            + PREFIX_CONTACT + "2";
+            + "Example: " + COMMAND_WORD_FULL + " "
+            + "New task "
+            + PREFIX_DEADLINE + "14 December 2000 "
+            + PREFIX_PROJECT + "CS2103t tp "
+            + PREFIX_CONTACT + "1 "
+            + PREFIX_CONTACT + "2 ";
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task panel";

--- a/src/main/java/seedu/address/logic/commands/task/AssignTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AssignTaskCommand.java
@@ -30,7 +30,7 @@ public class AssignTaskCommand extends TaskCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD_FULL + ": Assigns/unassigns person(s) to a task.\n"
             + "Parameters: "
             + "TASK_INDEX (must be a positive integer) "
-            + "[" + PREFIX_ADD_CONTACT + "CONTACT_INDEX OR CONTACT_NAME]...\n"
+            + "[" + PREFIX_ADD_CONTACT + "CONTACT_INDEX OR CONTACT_NAME]... "
             + "[" + PREFIX_DELETE_CONTACT + "CONTACT_INDEX OR CONTACT_NAME]...\n"
             + "Example: " + COMMAND_WORD_FULL + " "
             + "1 "
@@ -110,6 +110,7 @@ public class AssignTaskCommand extends TaskCommand {
                 taskToModify.getTitle(),
                 taskToModify.getCompleted(),
                 taskToModify.getDeadline(),
+                taskToModify.getProject(),
                 contactSetToModify
         );
 

--- a/src/main/java/seedu/address/logic/commands/task/DeadlineTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/DeadlineTaskCommand.java
@@ -66,6 +66,7 @@ public class DeadlineTaskCommand extends TaskCommand {
                         taskToUpdate.getTitle(),
                         taskToUpdate.getCompleted(),
                         newDeadline,
+                        taskToUpdate.getProject(),
                         taskToUpdate.getAssignedContacts()
         );
 

--- a/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
@@ -17,9 +17,9 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Title;
 

--- a/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.task;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.Collections;
@@ -16,6 +17,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Task;
@@ -32,11 +34,15 @@ public class EditTaskCommand extends TaskCommand {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TITLE + "TITLE] "
+            + "[" + PREFIX_PROJECT + "PROJECT NAME]\n"
             + "Example: " + COMMAND_WORD_FULL + " 1 "
-            + "Add tasks functionality";
+            + PREFIX_TITLE + "Add tasks functionality "
+            + PREFIX_PROJECT + "CS2103T tp ";
 
     public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+
+    public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task panel.";
 
     private final Index targetIndex;
     private final EditTaskDescriptor editTaskDescriptor;
@@ -66,6 +72,10 @@ public class EditTaskCommand extends TaskCommand {
 
         Task editedTask = createEditedTask(taskToEdit, editTaskDescriptor);
 
+        if (!taskToEdit.isSameTask(editedTask) && model.hasTask(editedTask)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TASK);
+        }
+
         // Replace task with edited task
         model.setTask(taskToEdit, editedTask);
 
@@ -81,8 +91,10 @@ public class EditTaskCommand extends TaskCommand {
         assert taskToEdit != null;
 
         Title updatedTitle = editTaskDescriptor.getTitle().orElse(taskToEdit.getTitle());
+        Project updatedProject = editTaskDescriptor.getProject().orElse(taskToEdit.getProject());
 
-        return new Task(updatedTitle);
+        return new Task(updatedTitle, taskToEdit.getCompleted(), taskToEdit.getDeadline(), updatedProject,
+                taskToEdit.getAssignedContacts());
     }
 
     @Override
@@ -112,6 +124,7 @@ public class EditTaskCommand extends TaskCommand {
         private Title title;
         private boolean isCompleted;
         private Deadline deadline;
+        private Project project;
         private Set<Contact> assignedContacts;
 
         public EditTaskDescriptor() {}
@@ -122,21 +135,30 @@ public class EditTaskCommand extends TaskCommand {
          */
         public EditTaskDescriptor(EditTaskDescriptor toCopy) {
             setTitle(toCopy.title);
+            setProject(toCopy.project);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(title);
+            return CollectionUtil.isAnyNonNull(title, project);
         }
 
         public void setTitle(Title title) {
             this.title = title;
         }
 
+        public void setProject(Project project) {
+            this.project = project;
+        }
+
         public Optional<Title> getTitle() {
             return Optional.ofNullable(title);
+        }
+
+        public Optional<Project> getProject() {
+            return Optional.ofNullable(project);
         }
 
         public void setCompleted(boolean isCompleted) {
@@ -188,6 +210,7 @@ public class EditTaskCommand extends TaskCommand {
             return getTitle().equals(e.getTitle())
                     && getCompleted() == e.getCompleted()
                     && getDeadline() == e.getDeadline()
+                    && getProject() == e.getProject()
                     && getAssignedContacts().equals(e.getAssignedContacts());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/task/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/MarkTaskCommand.java
@@ -53,6 +53,7 @@ public class MarkTaskCommand extends TaskCommand {
                 taskToMark.getTitle(),
                 true,
                 taskToMark.getDeadline(),
+                taskToMark.getProject(),
                 taskToMark.getAssignedContacts()
         );
 

--- a/src/main/java/seedu/address/logic/commands/task/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/UnmarkTaskCommand.java
@@ -53,6 +53,7 @@ public class UnmarkTaskCommand extends TaskCommand {
                 new Task(taskToUnmark.getTitle(),
                         false,
                         taskToUnmark.getDeadline(),
+                        taskToUnmark.getProject(),
                         taskToUnmark.getAssignedContacts());
 
         model.setTask(taskToUnmark, editedTask);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -18,5 +18,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_BEFORE = new Prefix("before");
     public static final Prefix PREFIX_AFTER = new Prefix("after");
     public static final Prefix PREFIX_TITLE = new Prefix("ti/");
+    public static final Prefix PREFIX_PROJECT = new Prefix("pr/");
     public static final Prefix PREFIX_FLAG = new Prefix("-");
 }

--- a/src/main/java/seedu/address/logic/parser/TaskParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/TaskParserUtil.java
@@ -15,9 +15,9 @@ import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Title;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/TaskParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/TaskParserUtil.java
@@ -15,6 +15,7 @@ import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Title;
@@ -65,6 +66,21 @@ public class TaskParserUtil {
         } else {
             throw new ParseException(Deadline.MESSAGE_PARSE_FAILURE);
         }
+    }
+
+    /**
+     * Parses a {@code String project name} into a {@code Project}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code project} is invalid.
+     */
+    public static Project parseProject(String projectName) throws ParseException {
+        requireNonNull(projectName);
+        String trimmedProjectName = projectName.trim();
+        if (!Project.isValidProjectName(trimmedProjectName)) {
+            throw new ParseException(Project.MESSAGE_CONSTRAINTS);
+        }
+        return new Project(trimmedProjectName);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -13,9 +13,9 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.TaskParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Title;
 

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.task;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
 import java.util.Set;
 
@@ -12,6 +13,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.TaskParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Task;
@@ -29,17 +31,25 @@ public class AddTaskCommandParser implements Parser<AddTaskCommand> {
      */
     public AddTaskCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DEADLINE, PREFIX_CONTACT);
+                ArgumentTokenizer.tokenize(args, PREFIX_DEADLINE, PREFIX_CONTACT, PREFIX_PROJECT);
 
-        if (argMultimap.getPreamble().isEmpty()) {
+        if (argMultimap.getPreamble().isEmpty() || argMultimap.getValue(PREFIX_DEADLINE).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTaskCommand.MESSAGE_USAGE));
         }
 
         Title title = TaskParserUtil.parseTitle(argMultimap.getPreamble());
         Deadline deadline = TaskParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get());
+
+        Project project;
+        if (argMultimap.getValue(PREFIX_PROJECT).isPresent()) {
+            project = TaskParserUtil.parseProject(argMultimap.getValue(PREFIX_PROJECT).get());
+        } else {
+            project = Project.UNSPECIFIED;
+        }
+
         Set<Contact> contactList = TaskParserUtil.parseContacts(argMultimap.getAllValues(PREFIX_CONTACT));
 
-        Task task = new Task(title, false, deadline, contactList);
+        Task task = new Task(title, false, deadline, project, contactList);
 
         return new AddTaskCommand(task);
     }

--- a/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
@@ -13,7 +13,7 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.TaskParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.project.Project;
+import seedu.address.model.task.Project;
 
 /**
  * Parses input arguments and creates a new EditTaskCommand object

--- a/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser.task;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import seedu.address.commons.core.index.Index;
@@ -12,6 +13,7 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.TaskParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.project.Project;
 
 /**
  * Parses input arguments and creates a new EditTaskCommand object
@@ -25,7 +27,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
     public EditTaskCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TITLE);
+                ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_PROJECT);
 
         Index targetIndex;
 
@@ -39,6 +41,15 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
             editTaskDescriptor.setTitle(TaskParserUtil
                     .parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_PROJECT).isPresent()) {
+            if (argMultimap.getValue(PREFIX_PROJECT).get().equals("")) {
+                editTaskDescriptor.setProject(Project.UNSPECIFIED);
+            } else {
+                editTaskDescriptor.setProject(TaskParserUtil
+                        .parseProject(argMultimap.getValue(PREFIX_PROJECT).get()));
+            }
         }
 
         if (!editTaskDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -1,0 +1,75 @@
+package seedu.address.model.project;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Project in the task panel.
+ * Guarantees: immutable; name is valid as declared in {@link #isValidProjectName(String)}
+ */
+public class Project {
+
+    public static final Project UNSPECIFIED = new Project();
+
+    public static final String UNSPECIFIED_PROJECT_IDENTIFIER = "";
+
+    public static final String MESSAGE_CONSTRAINTS = "Project names should be alphanumeric";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+
+    public final String projectName;
+
+    /**
+     * Constructs a {@code Project}.
+     *
+     * @param projectName A valid project name.
+     */
+    public Project(String projectName) {
+        requireNonNull(projectName);
+        checkArgument(isValidProjectName(projectName), MESSAGE_CONSTRAINTS);
+        this.projectName = projectName;
+    }
+
+    /**
+     * Constructs an empty {@code Project}.
+     */
+    private Project() {
+        this.projectName = "";
+    }
+
+    /**
+     * Returns true if a given string is a valid project name.
+     */
+    public static boolean isValidProjectName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a project is unspecified.
+     */
+    public boolean isUnspecified() {
+        return this == Project.UNSPECIFIED;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof seedu.address.model.project.Project // instanceof handles nulls
+                && projectName.equals(((seedu.address.model.project.Project) other).projectName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return projectName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        if (isUnspecified()) {
+            return UNSPECIFIED_PROJECT_IDENTIFIER;
+        }
+        return projectName;
+    }
+
+}

--- a/src/main/java/seedu/address/model/task/Project.java
+++ b/src/main/java/seedu/address/model/task/Project.java
@@ -1,7 +1,9 @@
-package seedu.address.model.project;
+package seedu.address.model.task;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.Locale;
 
 /**
  * Represents a Project in the task panel.
@@ -14,7 +16,12 @@ public class Project {
     public static final String UNSPECIFIED_PROJECT_IDENTIFIER = "";
 
     public static final String MESSAGE_CONSTRAINTS = "Project names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String projectName;
 
@@ -53,8 +60,9 @@ public class Project {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof seedu.address.model.project.Project // instanceof handles nulls
-                && projectName.equals(((seedu.address.model.project.Project) other).projectName)); // state check
+                || (other instanceof Project // instanceof handles nulls
+                && projectName.toLowerCase(Locale.ROOT).equals(((Project) other)
+                .projectName.toLowerCase(Locale.ROOT))); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -7,8 +7,6 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.address.model.project.Project;
-
 /**
  * Represents a Task in the task list.
  * Guarantees: details are present and not null, field values are validated, immutable.

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -7,6 +7,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.address.model.project.Project;
+
 /**
  * Represents a Task in the task list.
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -19,6 +21,8 @@ public class Task {
 
     // data fields
     private final Deadline deadline; // optional
+
+    private final Project project; // optional
     private final Set<Contact> assignedContacts = new HashSet<>();
 
     /**
@@ -27,18 +31,19 @@ public class Task {
      * @param title Title of task
      */
     public Task(Title title) {
-        this(title, false, Deadline.UNSPECIFIED, new HashSet<Contact>());
+        this(title, false, Deadline.UNSPECIFIED, Project.UNSPECIFIED, new HashSet<Contact>());
     }
 
     /**
      * Every field except the task's deadline must be present and not null.
      */
-    public Task(Title title, boolean isCompleted, Deadline deadline, Set<Contact> assignedContacts) {
-        requireAllNonNull(title, isCompleted, assignedContacts);
+    public Task(Title title, boolean isCompleted, Deadline deadline, Project project, Set<Contact> assignedContacts) {
+        requireAllNonNull(title, isCompleted, project, assignedContacts);
 
         this.title = title;
         this.isCompleted = isCompleted;
         this.deadline = deadline;
+        this.project = project;
         this.assignedContacts.addAll(assignedContacts);
     }
 
@@ -59,6 +64,13 @@ public class Task {
      */
     public Deadline getDeadline() {
         return deadline;
+    }
+
+    /**
+     * Returns the project the task belongs in.
+     */
+    public Project getProject() {
+        return project;
     }
 
     /**
@@ -99,6 +111,7 @@ public class Task {
         return otherTask.getTitle().equals(getTitle())
                 && otherTask.getCompleted() == getCompleted()
                 && otherTask.getDeadline().equals(getDeadline())
+                && otherTask.getProject().equals(getProject())
                 && otherTask.getAssignedContacts().equals(getAssignedContacts());
 
     }
@@ -106,7 +119,7 @@ public class Task {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(title, isCompleted, deadline, assignedContacts);
+        return Objects.hash(title, isCompleted, deadline, project, assignedContacts);
     }
 
     @Override
@@ -125,6 +138,11 @@ public class Task {
         if (!deadline.isUnspecified()) {
             builder.append("; Deadline: ");
             builder.append(deadline);
+        }
+
+        if (!project.isUnspecified()) {
+            builder.append("; Project: ");
+            builder.append(project);
         }
 
         return builder.toString();

--- a/src/main/java/seedu/address/model/task/Title.java
+++ b/src/main/java/seedu/address/model/task/Title.java
@@ -3,6 +3,8 @@ package seedu.address.model.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Locale;
+
 /**
  * Represents the title of a task.
  * Guarantees: immutable; is valid as declared in {@link #isValidTitle(String)}
@@ -44,7 +46,8 @@ public class Title {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Title //instanceof handles nulls
-                && value.equals(((Title) other).value)); // state check
+                && value.toLowerCase(Locale.ROOT).equals(((Title) other)
+                    .value.toLowerCase(Locale.ROOT))); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -13,10 +13,10 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.project.Project;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Title;
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.project.Project;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
@@ -56,8 +57,10 @@ public class SampleDataUtil {
 
     public static Task[] getSampleTasks() {
         return new Task[] {
-            new Task(new Title("Add task functionality."), false, Deadline.UNSPECIFIED, getContactSet("Alex Yeoh")),
-            new Task(new Title("Add task storage"), false, Deadline.UNSPECIFIED, getContactSet("Bernice Yu"))
+            new Task(new Title("Add task functionality."), false, Deadline.UNSPECIFIED, Project.UNSPECIFIED,
+                    getContactSet("Alex Yeoh")),
+            new Task(new Title("Add task storage"), false, Deadline.UNSPECIFIED, Project.UNSPECIFIED,
+                    getContactSet("Bernice Yu"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.parser.TaskParserUtil;
+import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Task;
@@ -25,6 +26,7 @@ class JsonAdaptedTask {
     private final String title;
     private final String isCompleted;
     private final String deadline;
+    private final String project;
     private final List<JsonAdaptedContact> assigned = new ArrayList<>();
 
     /**
@@ -34,10 +36,12 @@ class JsonAdaptedTask {
     public JsonAdaptedTask(@JsonProperty("title") String title,
                            @JsonProperty("isCompleted") String isCompleted,
                            @JsonProperty("deadline") String deadline,
+                           @JsonProperty("project") String project,
                            @JsonProperty("assigned") List<JsonAdaptedContact> assigned) {
         this.title = title;
         this.isCompleted = isCompleted;
         this.deadline = deadline;
+        this.project = project;
         if (assigned != null) {
             this.assigned.addAll(assigned);
         }
@@ -52,6 +56,8 @@ class JsonAdaptedTask {
         isCompleted = String.valueOf(source.getCompleted());
 
         deadline = source.getDeadline().toString();
+
+        project = source.getProject().toString();
 
         assigned.addAll(source.getAssignedContacts().stream()
             .map(JsonAdaptedContact::new)
@@ -95,9 +101,18 @@ class JsonAdaptedTask {
             modelDeadline = Deadline.of(TaskParserUtil.convertStringToLocalDate(deadline));
         }
 
+        final Project modelProject;
+        if (project.equals(Project.UNSPECIFIED_PROJECT_IDENTIFIER)) {
+            modelProject = Project.UNSPECIFIED;
+        } else if (!Project.isValidProjectName(project)) {
+            throw new IllegalValueException(Project.MESSAGE_CONSTRAINTS);
+        } else {
+            modelProject = new Project(project);
+        }
+
         final Set<Contact> modelContacts = new HashSet<>(assignedContacts);
 
-        return new Task(modelTitle, modelIsCompleted, modelDeadline, modelContacts);
+        return new Task(modelTitle, modelIsCompleted, modelDeadline, modelProject, modelContacts);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -11,9 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.parser.TaskParserUtil;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Title;
 

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -45,6 +45,8 @@ public class TaskCard extends UiPart<Region> {
     @FXML
     private Label deadline;
     @FXML
+    private Label project;
+    @FXML
     private FlowPane assignedContacts;
 
     /**
@@ -62,6 +64,14 @@ public class TaskCard extends UiPart<Region> {
         } else {
             String text = task.getDeadline().formatForUi();
             deadline.setText(text);
+        }
+
+        if (task.getProject().isUnspecified()) {
+            project.setVisible(false);
+            project.setManaged(false);
+        } else {
+            String text = task.getProject().toString();
+            project.setText(text);
         }
 
         isCompleted.setText("");

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -41,6 +41,7 @@
       </children>
       </HBox>
       <Label fx:id="deadline" text="\$first" styleClass="cell_big_label" />
+      <Label fx:id="project" text="\$first" styleClass="cell_big_label" />
       <FlowPane fx:id="assignedContacts" />
     </VBox>
   </GridPane>

--- a/src/test/data/JsonSerializableTaskPanelTest/duplicateTaskTaskPanel.json
+++ b/src/test/data/JsonSerializableTaskPanelTest/duplicateTaskTaskPanel.json
@@ -3,11 +3,13 @@
     "title": "Assign task to Alex",
     "isCompleted": "false",
     "deadline": "UNSPECIFIED",
+    "project": "",
     "contacts": [ "Alex Yeoh" ]
   }, {
     "title": "Assign task to Alex",
     "isCompleted": "false",
     "deadline": "UNSPECIFIED",
+    "project": "",
     "contacts": [ "Alex Yeoh" ]
   } ]
 }

--- a/src/test/data/JsonSerializableTaskPanelTest/typicalTasksTaskPanel.json
+++ b/src/test/data/JsonSerializableTaskPanelTest/typicalTasksTaskPanel.json
@@ -4,11 +4,13 @@
     "title": "Add tasks to list",
     "isCompleted": "false",
     "deadline": "UNSPECIFIED",
+    "project": "",
     "assigned": [ "Alice Pauline" ]
   }, {
     "title": "Assign contacts to task",
     "isCompleted": "false",
     "deadline": "01-01-2023",
+    "project": "CS2103T",
     "assigned": [ "George Best" ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
@@ -32,7 +32,11 @@ public class EditTaskCommandTest {
     void execute_allFieldsSpecified_success() {
         Index targetIndex = Index.fromOneBased(1);
         Task taskToEdit = model.getFilteredTaskList().get(targetIndex.getZeroBased());
-        Task editedTask = new TaskBuilder().build();
+        Task editedTask = new TaskBuilder()
+                .withCompleted(false)
+                .withContacts("Alice Pauline")
+                .withDeadline("?")
+                .build();
         EditTaskCommand.EditTaskDescriptor descriptor = new EditTaskDescriptorBuilder(editedTask).build();
         EditTaskCommand editTaskCommand = new EditTaskCommand(targetIndex, descriptor);
         String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask);

--- a/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
@@ -12,8 +12,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Title;
 
 public class JsonAdaptedTaskTest {

--- a/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedTaskTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.project.Project;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Title;
 
@@ -39,6 +40,7 @@ public class JsonAdaptedTaskTest {
                 INVALID_TITLE,
                 VALID_DONE,
                 Deadline.UNSPECIFIED_DEADLINE_IDENTIFIER,
+                Project.UNSPECIFIED_PROJECT_IDENTIFIER,
                 VALID_CONTACTS
         );
         String expectedMessage = Title.MESSAGE_CONSTRAINTS;
@@ -51,6 +53,7 @@ public class JsonAdaptedTaskTest {
                 null,
                 VALID_DONE,
                 Deadline.UNSPECIFIED_DEADLINE_IDENTIFIER,
+                Project.UNSPECIFIED_PROJECT_IDENTIFIER,
                 VALID_CONTACTS
         );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName());
@@ -63,6 +66,7 @@ public class JsonAdaptedTaskTest {
                 VALID_TITLE,
                 INVALID_DONE,
                 Deadline.UNSPECIFIED_DEADLINE_IDENTIFIER,
+                Project.UNSPECIFIED_PROJECT_IDENTIFIER,
                 VALID_CONTACTS
         );
         // TODO: Update Message
@@ -76,6 +80,7 @@ public class JsonAdaptedTaskTest {
                 VALID_TITLE,
                 null,
                 Deadline.UNSPECIFIED_DEADLINE_IDENTIFIER,
+                Project.UNSPECIFIED_PROJECT_IDENTIFIER,
                 VALID_CONTACTS
         );
         // TODO: Update Message
@@ -91,6 +96,7 @@ public class JsonAdaptedTaskTest {
                 VALID_TITLE,
                 VALID_DONE,
                 Deadline.UNSPECIFIED_DEADLINE_IDENTIFIER,
+                Project.UNSPECIFIED_PROJECT_IDENTIFIER,
                 invalidContacts
         );
         assertThrows(IllegalValueException.class, task::toModelType);

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -4,9 +4,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.logic.parser.TaskParserUtil;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Title;
 import seedu.address.model.util.SampleDataUtil;

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.logic.parser.TaskParserUtil;
+import seedu.address.model.project.Project;
 import seedu.address.model.task.Contact;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Task;
@@ -22,6 +23,7 @@ public class TaskBuilder {
     private Title title;
     private boolean isCompleted;
     private Deadline deadline;
+    private Project project;
     private Set<Contact> assignedContacts;
 
     /**
@@ -31,6 +33,7 @@ public class TaskBuilder {
         title = new Title(DEFAULT_TITLE);
         isCompleted = DEFAULT_IS_COMPLETED;
         deadline = Deadline.UNSPECIFIED;
+        project = Project.UNSPECIFIED;
         assignedContacts = new HashSet<>();
     }
 
@@ -41,6 +44,7 @@ public class TaskBuilder {
         title = taskToCopy.getTitle();
         isCompleted = taskToCopy.getCompleted();
         deadline = taskToCopy.getDeadline();
+        project = taskToCopy.getProject();
         assignedContacts = new HashSet<>(taskToCopy.getAssignedContacts());
     }
 
@@ -69,6 +73,16 @@ public class TaskBuilder {
     }
 
     /**
+     * Sets the {@code Project} of the {@code Task} that we are building.
+     */
+    public TaskBuilder withProject(String projectName) {
+        if (!projectName.equals("")) {
+            this.project = new Project(projectName);
+        }
+        return this;
+    }
+
+    /**
      * Parses the {@code contacts} into a {@code Set<Contact>} and set it to the {@code Task} that we are building.
      */
     public TaskBuilder withContacts(String... contacts) {
@@ -78,6 +92,6 @@ public class TaskBuilder {
 
 
     public Task build() {
-        return new Task(title, isCompleted, deadline, assignedContacts);
+        return new Task(title, isCompleted, deadline, project, assignedContacts);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -25,6 +25,7 @@ public class TypicalTasks {
                     .withCompleted(false)
                     .withDeadline("01 January 2023")
                     .withContacts("George Best")
+                    .withProject("CS2103T")
                     .build();
     public static final Task TASK_THREE = new TaskBuilder().withTitle("Set deadline for a task").build();
     public static final Task TASK_FOUR = new TaskBuilder().withTitle("Set tags for a task").build();


### PR DESCRIPTION
## Changes
- Users can now tag a project to a task when they task add.
- Users can now edit a project/untag a project from a task through task edit.
- Added checks for edit task to ensure new task name does not already exist in task panel.
- Updated storage to store project field
- Updated UI to display project field
- Edited affected test cases (now all test cases pass), but yet to add new test cases for this feature.

### Note
- To add new test cases to test feature in future PR.
- To add new test cases to ensure a duplicated task name is not added on "task edit" command.