### PR TITLE
Add support for projects in task list command and modified prefixes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -169,26 +169,26 @@ Format: `task list [KEYWORD] [#PROJECT]... [@PERSON_INDEX]... [before/ DATE] [af
 - If you do not specify any filters (i.e. `task list`), the command returns **all** tasks. You may find this useful to reset the task list after performing some filtering.
 
 #### Filtering by Description
-- The `KEYWORD` parameter allows you to search for tasks that contain `KEYWORD`
+- The `KEYWORD` parameter allows you to search for tasks that contain `KEYWORD`.
   - For example, `task list fix` returns all **incomplete** tasks whose description contains the keyword `fix`.
 
 #### Filtering by Project
 - The `#` parameter allows you to search for tasks that are assigned to **any** of the project(s) you specify.
-  - For example, `task list #CS2101 #CS2103T` returns all **incomplete** tasks that are **either** under the project `CS2101` **or** `CS2103T`
+  - For example, `task list #CS2101 #CS2103T` returns all **incomplete** tasks that are **either** under the project `CS2101` **or** `CS2103T`.
 
 #### Filtering by Assigned Contact(s)
 - The `@` parameter allows you to search for tasks that are assigned to **all** of the contact(s) you specify.
     - For example, `task list @1 @2` returns all **incomplete** tasks that are assigned to **both** the 1st and 2nd persons from the address book.
 
 #### Filtering by Deadline
-- The `before/` and `after/` parameters allow you to specify a date range to filter the tasks by, according to their deadline
+- The `before/` and `after/` parameters allow you to specify a date range to filter the tasks by, according to their deadline.
   - For example, `task list before/ next Monday after/ tomorrow` returns all **incomplete** tasks whose deadline is, well, after tomorrow but before next Monday.
 
 #### Filtering by Completion Status
 - Notice that the command seems to always return **incomplete** tasks. You can choose to opt out of this default behaviour with the `-a` parameter.
-  - For example, `task list -a` returns all tasks, **both** completed and incomplete ones
+  - For example, `task list -a` returns all tasks, **both** completed and incomplete ones,
 - Similarly, the `-c` filter allows you to search through **completed** tasks only.
-  - For example, `task list -c` returns all **completed** tasks
+  - For example, `task list -c` returns all **completed** tasks.
 
 ### Assigning contacts to a task: `task assign`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -160,18 +160,35 @@ Examples:
 * `task do 1 by/tomorrow` sets the deadline for the 1st task in the list to tomorrow.
 * `task do 1 by/?` **removes** the deadline from the 1st task in the list.
 
-### Listing all tasks : `task list`
+### Filtering the Tasks List: `task list`
 
 You can use the `task list` command to focus only on tasks that match your specified filter requirements.
 
-Format: `task list [ti/KEYWORD] [c/PERSON_INDEX]...`
-- The `task list` command accepts **optional** parameters that can filter tasks by their title or assigned contacts.
+Format: `task list [KEYWORD] [#PROJECT]... [c/PERSON_INDEX]... [before DATE] [after DATE]`
+- The `task list` command accepts **optional** parameters that can filter tasks by their description, project, due date or assigned contacts.
 - If you do not specify any filters (i.e. `task list`), the command returns **all** tasks. You may find this useful to reset the task list after performing some filtering.
 
-Examples:
-* `task list ti/fix` filters the task list to only display tasks that contain the keyword `fix`.
-* `task list c/1 c/2` filters the task list to only display tasks that are assigned to **both** the 1st and 2nd persons from the address book.
-* `task list ti/fix c/1 c/2` filters the task list to only display tasks that contain the keyword `fix` **and** that are assigned to **both** the 1st and 2nd persons from the address book.
+#### Filtering by Description
+- The `KEYWORD` parameter allows you to search for tasks that contain `KEYWORD`
+  - For example, `task list fix` returns all **incomplete** tasks whose description contains the keyword `fix`.
+
+#### Filtering by Project
+- The `#` parameter allows you to search for tasks that are assigned to **any** of the project(s) you specify.
+  - For example, `task list #CS2101 #CS2103T` returns all **incomplete** tasks that are **either** under the project `CS2101` **or** `CS2103T`
+
+#### Filtering by Assigned Contact(s)
+- The `c/` parameter allows you to search for tasks that are assigned to **all** of the contact(s) you specify.
+    - For example, `task list c/1 c/2` returns all **incomplete** tasks that are assigned to **both** the 1st and 2nd persons from the address book.
+
+#### Filtering by Deadline
+- The `before` and `after` parameters allow you to specify a date range to filter the tasks by, according to their deadline
+  - For example, `task list before next Monday after tomorrow` returns all **incomplete** tasks whose deadline is, well, after tomorrow but before next Monday.
+
+#### Filtering by Completion Status
+- Notice that the command seems to always return **incomplete** tasks. You can choose to opt out of this default behaviour with the `-a` parameter.
+  - For example, `task list -a` returns all tasks, **both** completed and incomplete ones
+- Similarly, the `-c` filter allows you to search through **completed** tasks only.
+  - For example, `task list -c` returns all **completed** tasks
 
 ### Assigning contacts to a task: `task assign`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -164,7 +164,7 @@ Examples:
 
 You can use the `task list` command to focus only on tasks that match your specified filter requirements.
 
-Format: `task list [KEYWORD] [#PROJECT]... [c/PERSON_INDEX]... [before DATE] [after DATE]`
+Format: `task list [KEYWORD] [#PROJECT]... [@PERSON_INDEX]... [before/ DATE] [after/ DATE]`
 - The `task list` command accepts **optional** parameters that can filter tasks by their description, project, due date or assigned contacts.
 - If you do not specify any filters (i.e. `task list`), the command returns **all** tasks. You may find this useful to reset the task list after performing some filtering.
 
@@ -177,12 +177,12 @@ Format: `task list [KEYWORD] [#PROJECT]... [c/PERSON_INDEX]... [before DATE] [af
   - For example, `task list #CS2101 #CS2103T` returns all **incomplete** tasks that are **either** under the project `CS2101` **or** `CS2103T`
 
 #### Filtering by Assigned Contact(s)
-- The `c/` parameter allows you to search for tasks that are assigned to **all** of the contact(s) you specify.
-    - For example, `task list c/1 c/2` returns all **incomplete** tasks that are assigned to **both** the 1st and 2nd persons from the address book.
+- The `@` parameter allows you to search for tasks that are assigned to **all** of the contact(s) you specify.
+    - For example, `task list @1 @2` returns all **incomplete** tasks that are assigned to **both** the 1st and 2nd persons from the address book.
 
 #### Filtering by Deadline
-- The `before` and `after` parameters allow you to specify a date range to filter the tasks by, according to their deadline
-  - For example, `task list before next Monday after tomorrow` returns all **incomplete** tasks whose deadline is, well, after tomorrow but before next Monday.
+- The `before/` and `after/` parameters allow you to specify a date range to filter the tasks by, according to their deadline
+  - For example, `task list before/ next Monday after/ tomorrow` returns all **incomplete** tasks whose deadline is, well, after tomorrow but before next Monday.
 
 #### Filtering by Completion Status
 - Notice that the command seems to always return **incomplete** tasks. You can choose to opt out of this default behaviour with the `-a` parameter.

--- a/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.task.AssignedToContactsPredicate;
+import seedu.address.model.task.ContainsProjectsPredicate;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.DeadlineIsAfterPredicate;
 import seedu.address.model.task.DeadlineIsBeforePredicate;
@@ -52,6 +53,7 @@ public class ListTasksCommand extends TaskCommand {
     private String keywordFilter;
     private Optional<Deadline> beforeArgs;
     private Optional<Deadline> afterArgs;
+    private List<String> projectNames;
     private List<String> flags;
     private final Set<Index> personIndexes = new HashSet<>();
 
@@ -60,12 +62,14 @@ public class ListTasksCommand extends TaskCommand {
      * @param personsIndexes a set of indexes to view only tasks assigned to the corresponding contacts
      */
     public ListTasksCommand(String keywordFilter,
+                            List<String> projectNames,
                             List<String> flags,
                             Optional<Deadline> beforeArgs,
                             Optional<Deadline> afterArgs,
                             Set<Index> personsIndexes) {
         requireAllNonNull(flags, personsIndexes);
         this.keywordFilter = keywordFilter;
+        this.projectNames = projectNames;
         this.flags = flags;
         this.beforeArgs = beforeArgs;
         this.afterArgs = afterArgs;
@@ -87,6 +91,7 @@ public class ListTasksCommand extends TaskCommand {
         }
 
         filter = filter.and(new TitleContainsKeywordPredicate(keywordFilter));
+        filter = filter.and(new ContainsProjectsPredicate(projectNames));
         filter = filter.and(parseDeadlineArgs());
         filter = filter.and(new AssignedToContactsPredicate(model, personIndexes));
 
@@ -153,27 +158,46 @@ public class ListTasksCommand extends TaskCommand {
         if (!keywordFilter.isEmpty()) {
             successMessage.append(String.format(" containing '%s'", keywordFilter));
         }
+
+        if (!projectNames.isEmpty()) {
+            int numNames = projectNames.size();
+            if (numNames == 1) {
+                successMessage.append(" assigned to the project");
+            } else {
+                successMessage.append(" assigned to any of the projects:");
+            }
+
+            projectNames
+                    .stream()
+                    .limit(numNames-1)
+                    .forEach(name -> successMessage.append(" '").append(name).append("',"));
+
+            successMessage.append(" '").append(projectNames.get(numNames-1)).append("'");
+        }
+
         if (!personIndexes.isEmpty()) {
             successMessage.append(
                     personIndexes.isEmpty()
                     ? ""
-                    : String.format("that are assigned to %s contacts", personIndexes.size())
+                    : String.format(" that are also assigned to %s contacts", personIndexes.size())
             );
         }
+
         if (beforeArgs.isPresent()) {
             Deadline before = beforeArgs.get();
             successMessage.append(
                     before.isUnspecified()
                             ? ""
-                            : String.format(" that are due before %s", before)
+                            : String.format(" that are also due before %s", before)
             );
         }
+
         if (afterArgs.isPresent()) {
             Deadline after = afterArgs.get();
             successMessage.append(
                     after.isUnspecified()
                             ? ""
-                            : String.format(" that are due after %s", after)
+                            : String.format(" that are also due after %s", after)
             );
         }
         return String.format(MESSAGE_SUCCESS, successMessage.toString());

--- a/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
@@ -115,6 +115,7 @@ public class ListTasksCommand extends TaskCommand {
         ListTasksCommand e = (ListTasksCommand) other;
         return keywordFilter.equals(e.keywordFilter)
                 && flags.equals(e.flags)
+                && projectNames.equals(e.projectNames)
                 && beforeArgs.equals(e.beforeArgs)
                 && afterArgs.equals(e.afterArgs)
                 && setIndexEquals(personIndexes, e.personIndexes);

--- a/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
@@ -2,7 +2,10 @@ package seedu.address.logic.commands.task;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AFTER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BEFORE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
 import java.util.HashSet;
 import java.util.List;
@@ -169,10 +172,10 @@ public class ListTasksCommand extends TaskCommand {
 
             projectNames
                     .stream()
-                    .limit(numNames-1)
+                    .limit(numNames - 1)
                     .forEach(name -> successMessage.append(" '").append(name).append("',"));
 
-            successMessage.append(" '").append(projectNames.get(numNames-1)).append("'");
+            successMessage.append(" '").append(projectNames.get(numNames - 1)).append("'");
         }
 
         if (!personIndexes.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTasksCommand.java
@@ -2,9 +2,7 @@ package seedu.address.logic.commands.task;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_AFTER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BEFORE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +39,7 @@ public class ListTasksCommand extends TaskCommand {
             + ": Lists all tasks that satisfy the specified requirements.\n"
             + "Parameters: "
             + "[" + "KEYWORD]"
+            + "[" + PREFIX_PROJECT + "PROJECT_NAME]...\n"
             + "[" + PREFIX_CONTACT + "CONTACT_INDEX]...\n"
             + "[" + PREFIX_BEFORE + "DATE]...\n"
             + "[" + PREFIX_AFTER + "DATE]...\n"

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -18,6 +18,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_BEFORE = new Prefix("before");
     public static final Prefix PREFIX_AFTER = new Prefix("after");
     public static final Prefix PREFIX_TITLE = new Prefix("ti/");
-    public static final Prefix PREFIX_PROJECT = new Prefix("pr/");
+    public static final Prefix PREFIX_PROJECT = new Prefix("#");
     public static final Prefix PREFIX_FLAG = new Prefix("-");
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,12 +11,12 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_CONTACT = new Prefix("c/");
+    public static final Prefix PREFIX_CONTACT = new Prefix("@");
     public static final Prefix PREFIX_ADD_CONTACT = new Prefix("+@");
     public static final Prefix PREFIX_DELETE_CONTACT = new Prefix("-@");
     public static final Prefix PREFIX_DEADLINE = new Prefix("by/");
-    public static final Prefix PREFIX_BEFORE = new Prefix("before");
-    public static final Prefix PREFIX_AFTER = new Prefix("after");
+    public static final Prefix PREFIX_BEFORE = new Prefix("before/");
+    public static final Prefix PREFIX_AFTER = new Prefix("after/");
     public static final Prefix PREFIX_TITLE = new Prefix("ti/");
     public static final Prefix PREFIX_PROJECT = new Prefix("#");
     public static final Prefix PREFIX_FLAG = new Prefix("-");

--- a/src/main/java/seedu/address/logic/parser/task/ListTasksCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/ListTasksCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_AFTER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BEFORE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FLAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,17 +38,20 @@ public class ListTasksCommandParser implements Parser<ListTasksCommand> {
                         args,
                         PREFIX_CONTACT,
                         PREFIX_FLAG,
+                        PREFIX_PROJECT,
                         PREFIX_BEFORE,
                         PREFIX_AFTER
                 );
         String keywordFilter = argMultimap.getPreamble();
         List<String> contactFilters = argMultimap.getAllValues(PREFIX_CONTACT);
+        List<String> projectNames = argMultimap.getAllValues(PREFIX_PROJECT);
         List<String> flags = argMultimap.getAllValues(PREFIX_FLAG);
         Optional<String> beforeArgs = argMultimap.getValue(PREFIX_BEFORE);
         Optional<String> afterArgs = argMultimap.getValue(PREFIX_AFTER);
 
         if (keywordFilter.isEmpty()
                 && contactFilters.isEmpty()
+                && projectNames.isEmpty()
                 && flags.isEmpty()
                 && beforeArgs.isEmpty()
                 && afterArgs.isEmpty()
@@ -76,7 +80,7 @@ public class ListTasksCommandParser implements Parser<ListTasksCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     ListTasksCommand.MESSAGE_USAGE), pe);
         }
-        return new ListTasksCommand(keywordFilter, flags, before, after, personsIndexes);
+        return new ListTasksCommand(keywordFilter, projectNames, flags, before, after, personsIndexes);
     }
 
 }

--- a/src/main/java/seedu/address/model/task/ContainsProjectsPredicate.java
+++ b/src/main/java/seedu/address/model/task/ContainsProjectsPredicate.java
@@ -10,7 +10,10 @@ import java.util.stream.Collectors;
 public class ContainsProjectsPredicate implements Predicate<Task> {
     private final List<String> projectNames;
 
-
+    /**
+     * Constructs an ContainsProjectsPredicate.
+     * @param projectNames the list of project names to search for
+     */
     public ContainsProjectsPredicate(List<String> projectNames) {
         this.projectNames = projectNames
                 .stream()

--- a/src/main/java/seedu/address/model/task/ContainsProjectsPredicate.java
+++ b/src/main/java/seedu/address/model/task/ContainsProjectsPredicate.java
@@ -1,0 +1,33 @@
+package seedu.address.model.task;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Tests that a {@code Task}'s {@code Project} matches any of the project names given.
+ */
+public class ContainsProjectsPredicate implements Predicate<Task> {
+    private final List<String> projectNames;
+
+
+    public ContainsProjectsPredicate(List<String> projectNames) {
+        this.projectNames = projectNames
+                .stream()
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return projectNames.isEmpty() || projectNames.contains(task.getProject().projectName.trim());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ContainsProjectsPredicate // instanceof handles nulls
+                && projectNames.equals(((ContainsProjectsPredicate) other).projectNames)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/task/ListTasksCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/ListTasksCommandTest.java
@@ -55,6 +55,7 @@ public class ListTasksCommandTest {
                 new ListTasksCommand(
                         "",
                         List.of(),
+                        List.of(),
                         Optional.empty(),
                         Optional.empty(),
                         new HashSet<>()
@@ -75,6 +76,7 @@ public class ListTasksCommandTest {
         ListTasksCommand command =
                 new ListTasksCommand(
                         "",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.empty(),
@@ -103,6 +105,7 @@ public class ListTasksCommandTest {
                 new ListTasksCommand(
                         "",
                         List.of(),
+                        List.of(),
                         Optional.empty(),
                         Optional.empty(),
                         personIndexes
@@ -121,6 +124,7 @@ public class ListTasksCommandTest {
         ListTasksCommand command =
                 new ListTasksCommand(
                         "ass",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.empty(),
@@ -146,6 +150,7 @@ public class ListTasksCommandTest {
                 new ListTasksCommand(
                         "test",
                         List.of(),
+                        List.of(),
                         Optional.empty(),
                         Optional.empty(),
                         new HashSet<>()
@@ -169,6 +174,7 @@ public class ListTasksCommandTest {
         ListTasksCommand command =
                 new ListTasksCommand(
                         "",
+                        List.of(),
                         List.of(ListTasksCommand.ALL_FLAG),
                         Optional.empty(),
                         Optional.of(Deadline.of(LocalDate.of(2022, 9, 20))),
@@ -193,6 +199,7 @@ public class ListTasksCommandTest {
         ListTasksCommand command =
                 new ListTasksCommand(
                         "",
+                        List.of(),
                         List.of(ListTasksCommand.ALL_FLAG),
                         Optional.of(Deadline.of(LocalDate.of(2022, 9, 20))),
                         Optional.empty(),
@@ -218,6 +225,7 @@ public class ListTasksCommandTest {
         ListTasksCommand command =
                 new ListTasksCommand(
                         "",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.empty(),
@@ -246,6 +254,7 @@ public class ListTasksCommandTest {
         ListTasksCommand command =
                 new ListTasksCommand(
                         "ass",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.empty(),

--- a/src/test/java/seedu/address/logic/commands/task/ListTasksCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/ListTasksCommandTest.java
@@ -28,6 +28,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.task.AssignedToContactsPredicate;
+import seedu.address.model.task.ContainsProjectsPredicate;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.DeadlineIsAfterPredicate;
 import seedu.address.model.task.DeadlineIsBeforePredicate;
@@ -269,4 +270,59 @@ public class ListTasksCommandTest {
         );
     }
 
+    @Test
+    public void execute_keywordAndProject_noResults() throws CommandException {
+        hideAllTasks(model);
+        Predicate<Task> basePredicate = Model.PREDICATE_INCOMPLETE_TASKS.and(new TitleContainsKeywordPredicate("ass"));
+
+        List<String> projectNames = List.of("Test Project");
+        ContainsProjectsPredicate projectsPredicate = new ContainsProjectsPredicate(projectNames);
+
+        expectedModel.updateFilteredTaskList(basePredicate.and(projectsPredicate));
+
+        ListTasksCommand command =
+                new ListTasksCommand(
+                        "ass",
+                        projectNames,
+                        List.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        new HashSet<>()
+                );
+
+        assertCommandSuccess(
+                command,
+                model,
+                command.getSuccessMessage(model),
+                expectedModel
+        );
+    }
+
+    @Test
+    public void execute_multipleProjects_noResults() throws CommandException {
+        hideAllTasks(model);
+        Predicate<Task> basePredicate = Model.PREDICATE_INCOMPLETE_TASKS;
+
+        List<String> projectNames = List.of("Test Project", "Another Project");
+        ContainsProjectsPredicate projectsPredicate = new ContainsProjectsPredicate(projectNames);
+
+        expectedModel.updateFilteredTaskList(basePredicate.and(projectsPredicate));
+
+        ListTasksCommand command =
+                new ListTasksCommand(
+                        "",
+                        projectNames,
+                        List.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        new HashSet<>()
+                );
+
+        assertCommandSuccess(
+                command,
+                model,
+                command.getSuccessMessage(model),
+                expectedModel
+        );
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/task/ListTasksCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/ListTasksCommandParserTest.java
@@ -27,6 +27,7 @@ public class ListTasksCommandParserTest {
                 new ListTasksCommand(
                         "",
                         List.of(),
+                        List.of(),
                         Optional.empty(),
                         Optional.empty(),
                         new HashSet<>()
@@ -37,6 +38,7 @@ public class ListTasksCommandParserTest {
                 " hi",
                 new ListTasksCommand(
                         "hi",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.empty(),
@@ -50,6 +52,7 @@ public class ListTasksCommandParserTest {
                 new ListTasksCommand(
                         "",
                         List.of(),
+                        List.of(),
                         Optional.empty(),
                         Optional.empty(),
                         new HashSet<>(Arrays.asList(INDEX_FIRST_PERSON))
@@ -62,6 +65,7 @@ public class ListTasksCommandParserTest {
                 " hi c/1 c/2",
                 new ListTasksCommand(
                         "hi",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.empty(),
@@ -77,6 +81,7 @@ public class ListTasksCommandParserTest {
                 " hi c/1 c/2 -c",
                 new ListTasksCommand(
                         "hi",
+                        List.of(),
                         List.of(ListTasksCommand.COMPLETED_FLAG),
                         Optional.empty(),
                         Optional.empty(),
@@ -89,6 +94,7 @@ public class ListTasksCommandParserTest {
                 " hi c/1 c/2 -a",
                 new ListTasksCommand(
                         "hi",
+                        List.of(),
                         List.of(ListTasksCommand.ALL_FLAG),
                         Optional.empty(),
                         Optional.empty(),
@@ -105,6 +111,7 @@ public class ListTasksCommandParserTest {
                 new ListTasksCommand(
                         "",
                         List.of(),
+                        List.of(),
                         Optional.of(Deadline.of(LocalDate.now().plusDays(1))),
                         Optional.empty(),
                         new HashSet<>()
@@ -116,6 +123,7 @@ public class ListTasksCommandParserTest {
                 " after today",
                 new ListTasksCommand(
                         "",
+                        List.of(),
                         List.of(),
                         Optional.empty(),
                         Optional.of(Deadline.of(LocalDate.now())),

--- a/src/test/java/seedu/address/logic/parser/task/ListTasksCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/ListTasksCommandParserTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.task.ListTasksCommand;
+import seedu.address.logic.parser.CliSyntax;
 import seedu.address.model.task.Deadline;
 
 public class ListTasksCommandParserTest {
@@ -48,7 +49,7 @@ public class ListTasksCommandParserTest {
 
         assertParseSuccess(
                 parser,
-                " c/1",
+                String.format(" %s1", CliSyntax.PREFIX_CONTACT),
                 new ListTasksCommand(
                         "",
                         List.of(),
@@ -62,7 +63,7 @@ public class ListTasksCommandParserTest {
 
         assertParseSuccess(
                 parser,
-                " hi c/1 c/2",
+                String.format(" hi %s1 %s2", CliSyntax.PREFIX_CONTACT, CliSyntax.PREFIX_CONTACT),
                 new ListTasksCommand(
                         "hi",
                         List.of(),
@@ -76,9 +77,13 @@ public class ListTasksCommandParserTest {
 
     @Test
     public void parse_validArgsWithFlags() {
+        String command1 = String.format(" hi %s1 %s2 -%s",
+                CliSyntax.PREFIX_CONTACT,
+                CliSyntax.PREFIX_CONTACT,
+                ListTasksCommand.COMPLETED_FLAG);
         assertParseSuccess(
                 parser,
-                " hi c/1 c/2 -c",
+                command1,
                 new ListTasksCommand(
                         "hi",
                         List.of(),
@@ -89,9 +94,13 @@ public class ListTasksCommandParserTest {
                 )
         );
 
+        String command2 = String.format(" hi %s1 %s2 -%s",
+                CliSyntax.PREFIX_CONTACT,
+                CliSyntax.PREFIX_CONTACT,
+                ListTasksCommand.ALL_FLAG);
         assertParseSuccess(
                 parser,
-                " hi c/1 c/2 -a",
+                command2,
                 new ListTasksCommand(
                         "hi",
                         List.of(),
@@ -107,7 +116,7 @@ public class ListTasksCommandParserTest {
     public void parse_nlp_deadlines() {
         assertParseSuccess(
                 parser,
-                " before tomorrow",
+                String.format(" %s tomorrow", CliSyntax.PREFIX_BEFORE),
                 new ListTasksCommand(
                         "",
                         List.of(),
@@ -120,7 +129,7 @@ public class ListTasksCommandParserTest {
 
         assertParseSuccess(
                 parser,
-                " after today",
+                String.format(" %s today", CliSyntax.PREFIX_AFTER),
                 new ListTasksCommand(
                         "",
                         List.of(),

--- a/src/test/java/seedu/address/model/task/ContainsProjectsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/ContainsProjectsPredicateTest.java
@@ -1,0 +1,66 @@
+package seedu.address.model.task;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.TaskBuilder;
+
+public class ContainsProjectsPredicateTest {
+    @Test
+    public void equals() {
+        List<String> firstPredicateContact = List.of("first");
+        List<String> secondPredicateContact = List.of("second");
+
+        ContainsProjectsPredicate firstPredicate = new ContainsProjectsPredicate(firstPredicateContact);
+        ContainsProjectsPredicate secondPredicate = new ContainsProjectsPredicate(secondPredicateContact);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ContainsProjectsPredicate firstPredicateCopy = new ContainsProjectsPredicate(firstPredicateContact);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_containsProject_returnsTrue() {
+        List<String> singleProject = List.of("Test Project");
+
+        ContainsProjectsPredicate predicate = new ContainsProjectsPredicate(singleProject);
+
+        Task testTask =
+                new TaskBuilder().withTitle("Test").withProject("Test Project").build();
+
+        assertTrue(predicate.test(testTask));
+
+        List<String> multipleProject = List.of("Test Project", "Another Project");
+        ContainsProjectsPredicate multiPredicate = new ContainsProjectsPredicate(multipleProject);
+        assertTrue(predicate.test(testTask));
+    }
+
+    @Test
+    public void test_doesNotContainProject_returnsFalse() {
+        List<String> singleProject = List.of("Test Project");
+
+        // Matching None
+        ContainsProjectsPredicate predicate = new ContainsProjectsPredicate(singleProject);
+        assertFalse(
+                predicate.test(new TaskBuilder().withTitle("Test").withProject("Another Project").build())
+        );
+    }
+
+}
+


### PR DESCRIPTION
#### Changes
- Users can now filter their task list by project
- Modified the following prefixes:
1. Contacts from "c/" to "@"
2. Projects from "pr/" to "#"
3. Before deadline from "before" to "before/"
4. After deadline from "after" to "after/"

Closes #101 
