### PR TITLE
Allow filtering of persons with tag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,13 +1,20 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.ContainsTagPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose name contains any of the argument keywords, or any of the
+ * argument tags.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
@@ -15,20 +22,31 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "the specified keywords (case-insensitive), or whose tags contain any of the specified tags, and "
+            + "displays them as a list with index numbers.\n"
+            + "Parameters: [NAME_KEYWORD]... "
+            + "[" + PREFIX_TAG + "TAG_KEYWORD]...\n"
+            + "Example: " + COMMAND_WORD + " alice bob charlie "
+            + PREFIX_TAG + "developers " + PREFIX_TAG + "qa";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final NameContainsKeywordsPredicate namePredicate;
+    private final ContainsTagPredicate tagsPredicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    /**
+     * @param namePredicate for names to filter
+     * @param tagsPredicate for tags to filter
+     */
+    public FindCommand(NameContainsKeywordsPredicate namePredicate, ContainsTagPredicate tagsPredicate) {
+        requireAllNonNull(namePredicate, tagsPredicate);
+        this.namePredicate = namePredicate;
+        this.tagsPredicate = tagsPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        Predicate<Person> filter = tagsPredicate.or(namePredicate);
+        model.updateFilteredPersonList(filter);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -37,6 +55,6 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && namePredicate.equals(((FindCommand) other).namePredicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,11 +1,17 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.ContainsTagPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -19,15 +25,27 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        requireNonNull(args);
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String namesJoined = argMultimap.getPreamble();
+        List<String> nameKeywords = Arrays.asList(namesJoined.split("\\s+"));
+        if (namesJoined.equals("")) {
+            nameKeywords = new ArrayList<>();
+        }
+
+        List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+        tagKeywords = tagKeywords.stream().map(x -> x.trim().toLowerCase()).collect(Collectors.toList());
+
+        return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
+                new ContainsTagPredicate(tagKeywords));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/ContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/ContainsTagPredicate.java
@@ -1,0 +1,35 @@
+package seedu.address.model.person;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s tags contains a specified set of tags.
+ */
+public class ContainsTagPredicate implements Predicate<Person> {
+
+    private final Set<String> tags = new HashSet<>();
+
+    /**
+     * Constructs an ContainsTagPredicate.
+     * @param tags the set of tags to search for
+     */
+    public ContainsTagPredicate(Collection<String> tags) {
+        this.tags.addAll(tags);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getTags().stream().map(x -> x.tagName.trim().toLowerCase()).anyMatch(tags::contains);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ContainsTagPredicate // instanceof handles nulls
+                && tags.equals(((ContainsTagPredicate) other).tags)); // state check
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
@@ -18,7 +16,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/ContainsProjectsPredicate.java
+++ b/src/main/java/seedu/address/model/task/ContainsProjectsPredicate.java
@@ -17,13 +17,13 @@ public class ContainsProjectsPredicate implements Predicate<Task> {
     public ContainsProjectsPredicate(List<String> projectNames) {
         this.projectNames = projectNames
                 .stream()
-                .map(String::trim)
+                .map(x -> x.trim().toLowerCase())
                 .collect(Collectors.toList());
     }
 
     @Override
     public boolean test(Task task) {
-        return projectNames.isEmpty() || projectNames.contains(task.getProject().projectName.trim());
+        return projectNames.isEmpty() || projectNames.contains(task.getProject().projectName.trim().toLowerCase());
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -11,6 +11,7 @@ import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskPanel;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ContainsTagPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -34,15 +36,16 @@ public class FindCommandTest {
                 new NameContainsKeywordsPredicate(Collections.singletonList("first"));
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        ContainsTagPredicate emptyTagsPredicate = new ContainsTagPredicate(new ArrayList<>());
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate, emptyTagsPredicate);
+        FindCommand findSecondCommand = new FindCommand(secondPredicate, emptyTagsPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, emptyTagsPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -59,7 +62,8 @@ public class FindCommandTest {
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        ContainsTagPredicate emptyTagsPredicate = new ContainsTagPredicate(new ArrayList<>());
+        FindCommand command = new FindCommand(predicate, emptyTagsPredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -69,7 +73,8 @@ public class FindCommandTest {
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        ContainsTagPredicate emptyTagsPredicate = new ContainsTagPredicate(new ArrayList<>());
+        FindCommand command = new FindCommand(predicate, emptyTagsPredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.ContainsTagPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -73,7 +75,8 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords),
+                        new ContainsTagPredicate(new ArrayList<>())), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,11 +4,13 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.ContainsTagPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -24,7 +26,8 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                        new ContainsTagPredicate(new ArrayList<>()));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords


### PR DESCRIPTION
## Changes
- Make filtering by project not case sensitive
- Enable filtering of persons by tag (using tag prefix /t)
- Make filter of persons by name less restrictive. eg. I have a persons "Charlotte Tan". Previously, "find Char" will not find her, have to match to "Charlotte" or "Tan". Now, can just do "find Char"