### PR TITLE
Update task edit command to remove ability to edit assigned contacts

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -318,12 +318,11 @@ Examples:
 
 Edits an existing task in the task list.
 
-Format: `task edit TASK_INDEX [ti/TITLE] [by/DEADLINE] [#/PROJECT] [+@PERSONS_INDEX] ... [-@PERSONS_INDEX]...`
+Format: `task edit TASK_INDEX [ti/TITLE] [by/DEADLINE] [#/PROJECT]`
 
 * Edits the person at the specified `TASK_INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing contacts, adding or removing contacts is cumulative. Not specifying any contacts to add will not change the data. Specify `+@PERSON_INDEX` to add and `-@PERSON_INDEX` to delete a contact.
 
 
 ### Listing all projects : `task project`

--- a/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/EditTaskCommandParser.java
@@ -8,11 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.task.EditTaskCommand;
 import seedu.address.logic.commands.task.EditTaskCommand.EditTaskDescriptor;
@@ -21,7 +16,6 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.TaskParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.task.Contact;
 import seedu.address.model.task.Project;
 
 /**
@@ -66,38 +60,11 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
                         .parseProject(argMultimap.getValue(PREFIX_PROJECT).get()));
             }
         }
-        if (argMultimap.getValue(PREFIX_ADD_CONTACT).isPresent()) {
-            editTaskDescriptor.setAssignedContactIndexes(TaskParserUtil
-                    .parseIndexes(argMultimap.getAllValues(PREFIX_ADD_CONTACT)));
-        }
-        if (argMultimap.getValue(PREFIX_DELETE_CONTACT).isPresent()) {
-            editTaskDescriptor.setUnassignedContactsIndexes(TaskParserUtil
-                    .parseIndexes(argMultimap.getAllValues(PREFIX_DELETE_CONTACT)));
-        }
 
         if (!editTaskDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditTaskCommand.MESSAGE_NOT_EDITED);
         }
 
         return new EditTaskCommand(targetIndex, editTaskDescriptor);
-    }
-
-    /**
-     * Parses {@code Collection<String> contacts} into a {@code Set<Contact>} if {@code contacts} is non-empty.
-     * If {@code contacts} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Contact>} containing zero contacts.
-     */
-    private Optional<Set<Contact>> parseContactsForEdit(Collection<String> contacts) throws ParseException {
-        assert contacts != null;
-
-        if (contacts.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Collection<String> contactSet = contacts.size() == 1 && contacts.contains("")
-            ? Collections.emptySet()
-            : contacts;
-
-        return Optional.of(TaskParserUtil.parseContacts(contactSet));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.task.EditTaskCommand.EditTaskDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -26,6 +27,7 @@ import seedu.address.testutil.EditTaskDescriptorBuilder;
 import seedu.address.testutil.TaskBuilder;
 
 public class EditTaskCommandTest {
+
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalTaskPanel(), new UserPrefs());
 
     @Test
@@ -37,7 +39,7 @@ public class EditTaskCommandTest {
                 .withContacts("Alice Pauline")
                 .withDeadline("?")
                 .build();
-        EditTaskCommand.EditTaskDescriptor descriptor = new EditTaskDescriptorBuilder(editedTask).build();
+        EditTaskDescriptor descriptor = new EditTaskDescriptorBuilder(editedTask).build();
         EditTaskCommand editTaskCommand = new EditTaskCommand(targetIndex, descriptor);
         String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask);
 

--- a/src/test/java/seedu/address/testutil/EditTaskDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditTaskDescriptorBuilder.java
@@ -1,12 +1,8 @@
 package seedu.address.testutil;
-//
-//import java.util.Set;
-//import java.util.stream.Collectors;
-//import java.util.stream.Stream;
 
 import seedu.address.logic.commands.task.EditTaskCommand.EditTaskDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
-// import seedu.address.model.task.Contact;
+import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Project;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Title;
 
@@ -32,7 +28,7 @@ public class EditTaskDescriptorBuilder {
         descriptor = new EditTaskDescriptor();
         descriptor.setTitle(task.getTitle());
         descriptor.setDeadline(task.getDeadline());
-        // descriptor.setAssignedContactIndexes(task.getAssignedContacts());
+        descriptor.setProject(task.getProject());
     }
 
     /**
@@ -46,20 +42,18 @@ public class EditTaskDescriptorBuilder {
     /**
      * Sets the {@code Deadline} of the {@code EditTaskDescriptor} that we are building.
      */
-    public EditTaskDescriptorBuilder withDeadline(String deadline) throws ParseException {
-        // descriptor.setDeadline(new Deadline(deadline));
+    public EditTaskDescriptorBuilder withDeadline(String deadline) {
+        descriptor.setDeadline(new Deadline(deadline));
         return this;
     }
 
-    //    /**
-    //     * Parses the {@code contacts} into a {@code Set<Contact>} and set it to the {@code EditTaskDescriptor}
-    //     * that we are building.
-    //     */
-    //    public EditTaskDescriptorBuilder withAssignedContacts(String... assignedContacts) {
-    //        Set<Contact> contactSet = Stream.of(assignedContacts).map(Contact::new).collect(Collectors.toSet());
-    //        descriptor.setAssignedContactIndexes(contactSet);
-    //        return this;
-    //    }
+    /**
+     * Sets the {@code Project} of the {@code EditTaskDescriptor} that we are building.
+     */
+    public EditTaskDescriptorBuilder withProject(String project) {
+        descriptor.setProject(new Project(project));
+        return this;
+    }
 
     public EditTaskDescriptor build() {
         return descriptor;


### PR DESCRIPTION
## Changes
- `task edit` was updated to be only able to edit the title, project and deadline of a `Task`.