### PR TITLE
Date format bug fix

### DIFF
--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -22,7 +22,7 @@ public class Deadline implements Comparable<Deadline> {
             DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
     public static final DateTimeFormatter READABLE_FORMATTER_WITHOUT_YEAR =
             DateTimeFormatter.ofPattern("EEE, dd MMM");
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM-dd-yyyy");
     private static final String VALIDATION_REGEX = "^[a-zA-Z0-9 ?]+$";
 
     private final LocalDate date;


### PR DESCRIPTION
## Changes

Previously, date format in Deadline was "dd-MM-yyyy".
However, PrettyTimeParser parses dates of the form "XX-XX-yyyy" as "MM-dd-yyyy" instead.
This leads to inconsistencies when saving data to file and loading it back. (every time date is saved, date and month is swapped)

Date format in Deadline is hence changed to "MM-dd-yyyy" for consistency. Dates in data file will hence also be saved in the "MM-dd-yyyy" format.