### PR TITLE
Update task project documentation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -486,7 +486,8 @@ Format: `task edit TASK_INDEX [ti/TITLE] [by/DEADLINE] [#/PROJECT]`
 ---
 ### Listing all projects: `task project`
 
-Lists all the projects present in the task list.
+Lists all the projects present in the task panel.<br>
+Projects of hidden tasks will also be shown.
 
 Format: `task project`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -489,6 +489,8 @@ Format: `task edit TASK_INDEX [ti/TITLE] [by/DEADLINE] [#/PROJECT]`
 Lists all the projects present in the task panel.<br>
 Projects of hidden tasks will also be shown.
 
+>:information_source: The task panel will not be changed to show only tasks with project.
+
 Format: `task project`
 
 ### Saving the data


### PR DESCRIPTION
## Changes
- Update `task project` documentation to indicate that the command will show all project including those of hidden tasks.

Closes #159
Closes #170